### PR TITLE
feat: add metrics for total IKE count and inactive connection states

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -216,10 +216,26 @@ func (c *StrongswanCollector) Collect (ch chan<- prometheus.Metric) {
 			prometheus.GaugeValue, //Type
 			float64(0), //Value
 		)
+		ch <- prometheus.MustNewConstMetric(
+			c.ikeCnt, //Description
+			prometheus.GaugeValue, //Type
+			float64(0), //Value
+		)
 		return
+	}
+	ikeConnCnt := 0
+	for _, ike := range data {
+		if ike.State == "ESTABLISHED" {
+			ikeConnCnt++
+		}
 	}
 	ch <- prometheus.MustNewConstMetric(
 		c.ikeConnCnt, //Description
+		prometheus.GaugeValue, //Type
+		float64(ikeConnCnt), //Value
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.ikeCnt, //Description
 		prometheus.GaugeValue, //Type
 		float64(len(data)), //Value
 	)

--- a/exporter.go
+++ b/exporter.go
@@ -223,10 +223,19 @@ func (c *StrongswanCollector) Collect (ch chan<- prometheus.Metric) {
 		)
 		return
 	}
+	ch <- prometheus.MustNewConstMetric(
+		c.ikeCnt, //Description
+		prometheus.GaugeValue, //Type
+		float64(len(data)), //Value
+	)
 	ikeConnCnt := 0
-	for _, ike := range data {
-		if ike.State == "ESTABLISHED" {
+	for _,v := range data {
+		if v.State == "ESTABLISHED" {
 			ikeConnCnt++
+		}
+		c.collectIkeMetrics(v, ch)
+		for _, child := range v.Children {
+			c.collectSaMetrics(v.Name, v.UniqueId, child, ch)
 		}
 	}
 	ch <- prometheus.MustNewConstMetric(
@@ -234,17 +243,6 @@ func (c *StrongswanCollector) Collect (ch chan<- prometheus.Metric) {
 		prometheus.GaugeValue, //Type
 		float64(ikeConnCnt), //Value
 	)
-	ch <- prometheus.MustNewConstMetric(
-		c.ikeCnt, //Description
-		prometheus.GaugeValue, //Type
-		float64(len(data)), //Value
-	)
-	for _,v := range data {
-		c.collectIkeMetrics(v, ch)
-		for _, child := range v.Children {
-			c.collectSaMetrics(v.Name, v.UniqueId, child, ch)
-		}
-	}
 }
 func (c *StrongswanCollector) collectIkeMetrics(d LoadedIKE, ch chan<- prometheus.Metric){
 	ch <- prometheus.MustNewConstMetric(

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func listSAs() ([]LoadedIKE, error) {
 	defer cancel()
 
 	var in *vici.Message
+	active := make(map[string]bool)
 
 	for m, err := range s.CallStreaming(ctx, "list-sas", "list-sa", in) { // <- Directly iterate over msgs
 		if e := m.Err(); e != nil || err != nil {
@@ -43,8 +44,23 @@ func listSAs() ([]LoadedIKE, error) {
 				//ignoring this marshal/unmarshal error!
 				continue
 			}
+			active[k] = true
 			ike.Name = k
 			retVar = append(retVar, ike)
+		}
+	}
+	for m, err := range s.CallStreaming(ctx, "list-conns", "list-conn", in) {
+		if e := m.Err(); e != nil || err != nil {
+			//ignoring this error
+			continue
+		}
+		// Each key is a connection name
+		for _, k := range m.Keys() {
+			if !active[k] {
+				var ike LoadedIKE
+				ike.Name = k
+				retVar = append(retVar, ike)
+			} 
 		}
 	}
 


### PR DESCRIPTION
This PR introduces two enhancements to provide better visibility when multiple connections are configured, especially those that are currently inactive:

    strongswan_number_of_known_ikes: A gauge representing the total number of IKE SAs currently managed by the daemon.
    strongswan_ike_state: A gauge showing the state of each connection.
        Value 1 indicates the connection is in the state represented by the labels.
        Value 0 indicates the connection is configured but not currently in that state.

Example output:

    strongswan_ike_state{name="ipsec1",uniqueid="1} 1
    strongswan_ike_state{name="ipsec2",uniqueid=""} 0

Reasoning:

    Currently, the exporter primarily provides metrics for active sessions. Inactive or "stuck" configured connections are not visible. These metrics allow users to monitor the health of the entire configuration, not just active traffic.

Changes:

    Implemented a call to list-conns to identify all configured tunnels.
    Added logic to cross-reference list-conns with list-sas.
    Defined strongswan_ike_state as 0 for inactive connections to ensure they appear in the metrics even when down.

Testing:

    Verified against strongSwan 5.9 using swanctl.
    Validated Prometheus output at /metrics.